### PR TITLE
Add X-GNOME-SystemSettings as Category to YaST.desktop

### DIFF
--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sat Mar 30 14:54:01 UTC 2013 - dimstar@opensuse.org
+
+- Add X-GNOME-SystemSettings as category to YaST.desktop: allows
+  YaST to be seen by gnome-control-center and to be added
+  transparently.
+
+-------------------------------------------------------------------
 Tue Feb 26 15:20:07 CET 2013 - tgoettlicher@suse.de
 
 - Adapted requirement for libyui-qt4

--- a/yast2-control-center.spec.in
+++ b/yast2-control-center.spec.in
@@ -65,7 +65,7 @@ make install DESTDIR=$RPM_BUILD_ROOT
 cd ..
 
 
-%suse_update_desktop_file -G "Administrator Settings"  %{buildroot}%{_datadir}/applications/YaST.desktop Core-System X-SuSE-ControlCenter-System
+%suse_update_desktop_file -G "Administrator Settings"  %{buildroot}%{_datadir}/applications/YaST.desktop Core-System X-SuSE-ControlCenter-System X-GNOME-SystemSettings
 %suse_update_desktop_file %{buildroot}%{_datadir}/kde4/services/YaST-systemsettings.desktop 
 
 %clean


### PR DESCRIPTION
This allows YaST to be shown in gnome-control-center as System Settings component.
