### PR TITLE
Add appdata.xml, to show up in GNOME Software

### DIFF
--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr  8 10:26:53 UTC 2015 - dimstar@opensuse.org
+
+- Install appdata.xml file in order to show up in AppStream based
+  software centers (currently only GNOME Software).
+
+-------------------------------------------------------------------
 Thu Oct 30 21:22:52 UTC 2014 - hrvoje.senjan@gmail.com
 
 - Install YaST-systemsettings.desktop also to KF5 services directory,

--- a/package/yast2-control-center.spec
+++ b/package/yast2-control-center.spec
@@ -98,6 +98,8 @@ rm -rf "$RPM_BUILD_ROOT"
 
 %files
 %defattr(-,root,root)
+%dir %{_datadir}/appdata
+%{_datadir}/appdata/YaST.appdata.xml
 %{_datadir}/applications/YaST.desktop
 %dir %{_datadir}/kde4/
 %dir %{_datadir}/kde4/services

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,7 @@ INSTALL(FILES yast.png DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pixmaps )
 INSTALL(FILES YaST.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications )
 INSTALL(FILES YaST-systemsettings.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/kde4/services )
 INSTALL(FILES YaST-systemsettings.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/kservices5 )
+INSTALL(FILES YaST.appdata.xml DESTINATION ${CMAKE_INSTALL_PREFIX}/share/appdata )
 
 SET(MODELS_TEST_SRCS
   models_test.cpp

--- a/src/YaST.appdata.xml
+++ b/src/YaST.appdata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+  <id type="desktop">YaST.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>YaST</name>
+  <summary>Configuration / Control center</summary>
+  <description>
+    <p>
+      YaST is both an extremely flexible installer and a powerful control center. It's an all-purpose tool for computing.		  
+    </p>
+    <p>
+      A multitude of modules allows to flexibly extend the capabilities of YaST.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">http://yast.github.io/assets/images/screenshots/screenshot_1.png</screenshot>
+  </screenshots>
+  <url type="homepage">http://yast.github.io/</url>
+  <updatecontact>yast-devel@opensuse.org</updatecontact>
+</application>


### PR DESCRIPTION
This allows yast (as main package) to show up in GNOME Software.

The next step is to add *.metainfo.xml files to the yast modules, so they show as extenstions to yast in GNOME Software