### PR TITLE
Adjusted to increased so version of the libyui library

### DIFF
--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug  9 12:01:20 UTC 2017 - mvidner@suse.com
+
+- Adjusted to increased so version of the libyui library;
+  an unversioned dependency is OK (bsc#1052217)
+- 3.3.0
+
+-------------------------------------------------------------------
 Tue May  2 13:20:35 UTC 2017 - i@xuzhao.net
 
 - Added support for 128x128 sized X11 window icon

--- a/package/yast2-control-center.spec
+++ b/package/yast2-control-center.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-control-center
-Version:        3.2.0
+Version:        3.3.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -57,7 +57,7 @@ Group:          System/YaST
 Requires:       yast2-control-center
 Provides:       yast2-control-center-binary
 Provides:       yast2-control-center:%{_prefix}/lib/YaST2/bin/y2controlcenter
-Requires:       libyui-qt7
+Requires:       libyui-qt
 Supplements:    kdebase3
 Supplements:    kdebase4-session
 Supplements:    plasma5-session


### PR DESCRIPTION
an unversioned dependency is OK (bsc#1052217)