### PR TITLE
Replace rpc/types.h with sys/param.h. We don't use RPC functions

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -24,7 +24,7 @@
 #include "i18n.h"
 
 #include <unistd.h>
-#include <rpc/types.h>
+#include <sys/param.h>
 #include <stdlib.h> 
 #include <time.h>
 #include <iostream>


### PR DESCRIPTION
and the rpc/types.h is deprecated in glibc.