### PR TITLE
Bump version and add changelog for previous commit

### DIFF
--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Nov 13 12:44:08 UTC 2017 - kukuk@suse.com
+
+- Do not included unused RPC headers (boo#1081118).
+- 4.0.0
+
+-------------------------------------------------------------------
 Wed Aug  9 12:01:20 UTC 2017 - mvidner@suse.com
 
 - Adjusted to increased so version of the libyui library;

--- a/package/yast2-control-center.spec
+++ b/package/yast2-control-center.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-control-center
-Version:        3.3.0
+Version:        4.0.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION

changelog / version was missed in #19 which resulted in the change not trickling down to Factory, now causing resulting in build fails, as glibc/rpc change is landing