### PR TITLE
Support for system-wide icon themes

### DIFF
--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Wed Feb 21 16:30:37 UTC 2018 - letcp@protonmail.com
 
-- Fixes to way icons are displayed
+- Fixes to way icons are displayed (boo#1081517)
 - 4.0.1
 
 -------------------------------------------------------------------

--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 21 16:30:37 UTC 2018 - letcp@protonmail.com
+
+- Fixes to way icons are displayed
+- 4.0.1
+
+-------------------------------------------------------------------
 Mon Nov 13 12:44:08 UTC 2017 - kukuk@suse.com
 
 - Do not included unused RPC headers (boo#1081118).

--- a/package/yast2-control-center.spec
+++ b/package/yast2-control-center.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-control-center
-Version:        4.0.0
+Version:        4.0.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/yqdesktopfilesmodel.cpp
+++ b/src/yqdesktopfilesmodel.cpp
@@ -278,20 +278,26 @@ QVariant YQDesktopFilesModel::translatedPropertyValue( const QModelIndex &index,
  
 QVariant YQDesktopFilesModel::findIcon(  QString &icon ) const
 {
-    QRegExp extension( "\\.(png|jpg)$", Qt::CaseInsensitive );
-    if ( icon.indexOf( extension ) < 0 )	// no .png or .jpg extension?
-        icon += ".png";			// assume .png
-    QStringListIterator it(d->icon_dirs);
-    while (it.hasNext())
+    if ( QIcon::hasThemeIcon(icon) )
     {
-        QString icondir(it.next());
-        if ( QFile::exists(icondir + "/" + icon) )
+        return QIcon::fromTheme(icon);
+    }
+    else
+    {
+        QRegExp extension( "\\.(png|jpg|svg)$", Qt::CaseInsensitive );
+        if ( icon.indexOf( extension ) < 0 )	// no .png or .jpg extension?
+            icon += ".png";			// assume .png
+        QStringListIterator it(d->icon_dirs);
+        while (it.hasNext())
         {
-            return QIcon(icondir + "/" + icon);
+            QString icondir(it.next());
+            if ( QFile::exists(icondir + "/" + icon) )
+            {
+                return QIcon(icondir + "/" + icon);
+            }
         }
     }
     return QVariant();
-
 }
  
 void YQDesktopFilesModel::sort( int, Qt::SortOrder order )


### PR DESCRIPTION
Adds support for icon themes in GTK and Qt environments. This patch fixes part of [this issue](https://github.com/yast/yast-yast2/issues/689) and boo#1081517 (but not the whole thing as there are many more parts of YaST that need patching before they work properly with icon themes)