### PR TITLE
L3: Fix crash when "X-SuSE-YaST-Group" is missing or is unknown (bsc#1090843)

### DIFF
--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 14 13:36:00 UTC 2018 - lslezak@suse.cz
+
+- Fixed crash when reading an invalid or incomplete .desktop file
+  (bsc#1090843)
+- 3.2.1
+
+-------------------------------------------------------------------
 Tue May  2 13:20:35 UTC 2017 - i@xuzhao.net
 
 - Added support for 128x128 sized X11 window icon

--- a/package/yast2-control-center.spec
+++ b/package/yast2-control-center.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-control-center
-Version:        3.2.0
+Version:        3.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/yqdesktopfilesmodel.h
+++ b/src/yqdesktopfilesmodel.h
@@ -41,6 +41,9 @@ typedef QMapIterator<QString, QVariant> PropertyMapIterator;
 // desktop file -> properties
 typedef QMap<QString, PropertyMap > PropertyMapCache;
 typedef QMapIterator<QString, PropertyMap> PropertyMapCacheIterator;
+// mutable iterator, if you do not need to add/remove values use
+// PropertyMapCacheIterator, it's more efficient
+typedef QMutableMapIterator<QString, PropertyMap> PropertyMapCacheMutableIterator;
 
 class cmp;
 

--- a/src/yqmodulesmodel.cpp
+++ b/src/yqmodulesmodel.cpp
@@ -227,6 +227,32 @@ void YQModulesModel::removeEmptyGroups()
  	groups <<  groupsModel()->groupId( idx );
     }
 
+    // filter out the .desktop files with unknown or missing group otherwise grouping aborts later
+    PropertyMapCacheMutableIterator it(d->cache);
+    while ( it.hasNext() )
+    {
+        it.next();
+
+        if ( !it.value().contains("X-SuSE-YaST-Group") )
+        {
+            QString file = it.key();
+            qWarning() << "Warning: Skipping file" << file << ": missing group attribute (X-SuSE-YaST-Group)";
+            d->desktop_files.removeAll( file );
+            it.remove();
+            continue;
+        }
+
+        QString group = it.value().value("X-SuSE-YaST-Group").toString();
+        if ( !groups.contains( group ) )
+        {
+            QString file = it.key();
+            qWarning() << "Warning: Skipping file" << file << ": unknown group (X-SuSE-YaST-Group)" << group
+                << "- currently defined groups:" << groups;
+            d->desktop_files.removeAll( file );
+            it.remove();
+        }
+    }
+
     QStringListIterator  git(groups);
     while (git.hasNext())
     {


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1090843
- When `X-SuSE-YaST-Group` value is missing or uses an unknown value then the item cannot be properly grouped in the view (causes out of array index and crash)
- This fix filters out the invalid files

The added warnings print messages like
```
# ./y2controlcenter
Warning: Skipping file "/usr/share/applications/YaST2/sap-windows_cheat_sheet.desktop" : 
missing group attribute (X-SuSE-YaST-Group)
```
or 
```
# ./y2controlcenter
Warning: Skipping file "/usr/share/applications/YaST2/sap-windows_cheat_sheet.desktop" : 
unknown group (X-SuSE-YaST-Group) "Test" - currently defined groups: ("Software", "Hardw
are", "High_Availability", "System", "Net_advanced", "Security", "Virtualization", "Supp
ort", "Misc")
```

## Desktopfile Example

Here is the .desktop file from the bug report:
```desktop
[Desktop Entry]
Type=Application
Categories=MIME;X-SuSE-YaST;X-SuSE-YaST-Software;

X-KDE-ModuleType=Library
X-KDE-RootOnly=true
X-KDE-HasReadOnlyMode=true
X-KDE-Library=yast2
X-SuSE-YaST-Call=sap-installation-wizard

X-SuSE-translate=false

Icon=yast-support
Exec=/usr/bin/firefox /usr/share/doc/packages/sap-installation-wizard/windows_cheat_sheet.pdf

Name=Cheat Sheet for Windows Admins
GenericName=Cheat Sheet
X-KDE-SubstituteUID=true
```

As you can see the file is actually completely broken as it displays a PDF document when used in the desktop environment but it still defines some YaST keys for the control center. But anyway, the YaST Control Center should not crash in that case.

The missing `X-SuSE-YaST-Group` value causes a crash when finding the group in which the module should be displayed.

I found out that the same problem happens when an unknown group is used in a desktop file.