### PR TITLE
Require libQt5SVG5 to support SVG icons

### DIFF
--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr  8 15:05:04 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Require libQt5Svg5 to support SVG icons (bsc#1127245)
+- 4.1.8
+
+-------------------------------------------------------------------
 Thu Feb 28 16:04:39 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Introduce very effective fallback for icons (boo#1127245)

--- a/package/yast2-control-center.spec
+++ b/package/yast2-control-center.spec
@@ -60,6 +60,10 @@ Requires:       yast2-control-center
 Provides:       yast2-control-center-binary
 Provides:       yast2-control-center:%{_prefix}/lib/YaST2/bin/y2controlcenter
 Requires:       libyui-qt
+
+# bsc#1130700: Need Qt SVG support for icons
+Requires:       libQt5Svg5
+
 Supplements:    kdebase3
 Supplements:    kdebase4-session
 Supplements:    plasma5-session

--- a/package/yast2-control-center.spec
+++ b/package/yast2-control-center.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-control-center
-Version:        4.1.7
+Version:        4.1.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1130700
https://bugzilla.suse.com/show_bug.cgi?id=1127245

## Trello

https://trello.com/c/E1q7m7cc/923-betasles-15-sp1-p2-1130700-icons-in-yast-control-center-still-missing-was-bug1127245

## Problem

No icons in YaST2 Qt control center.

![elite01-15-0-2-2019-02-25-16-32-12](https://user-images.githubusercontent.com/11538225/55735648-0cb3ab00-5a22-11e9-81a3-4e1110d21d50.png)

## Cause

No SVG plug-in for Qt installed.

## Fix

Require the plug-in.