### PR TITLE
Fixes for %_libexecdir changing to /usr/libexec

### DIFF
--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jul  7 09:49:24 UTC 2020 - Callum Farmer <callumjfarmer13@gmail.com>
+
+- Fixes for %_libexecdir changing to /usr/libexec
+
+-------------------------------------------------------------------
 Tue Dec 22 21:27:38 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Fix theming icons again (boo#1159283)

--- a/package/yast2-control-center.spec
+++ b/package/yast2-control-center.spec
@@ -110,7 +110,7 @@ cd ..
 %{yast_icondir}
 
 %files qt
-%{_libexecdir}/YaST2/bin/y2controlcenter
+%{_prefix}/lib/YaST2/bin/y2controlcenter
 %license COPYING.GPL2
 
 %changelog


### PR DESCRIPTION
* Fixes for %_libexecdir changing to /usr/libexec

close #47 