### PR TITLE
Call clients with nohup

### DIFF
--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jul 21 14:43:12 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Run clients with nohup to avoid signal error messages when the
+  control center is closed before than the client window
+  (bsc#1154854).
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0 (bsc#1185510)

--- a/package/yast2-control-center.spec
+++ b/package/yast2-control-center.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-control-center
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Url:            https://github.com/yast/yast-control-center
 Summary:        YaST2 - Control Center

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -290,7 +290,8 @@ void MainWindow::slotLaunchModule( const QModelIndex &index)
     QString argument = d->modmodel->data( i2, Qt::UserRole ).toString();
     QString name = d->modmodel->data( i3, Qt::UserRole ).toString();
 
-    QString cmd = QString("/sbin/yast2 ");
+    // Do not send HUP signal when control center is closed, bsc#1154854.
+    QString cmd = QString("/usr/bin/nohup /sbin/yast2 ");
     cmd += client;
 
     if ( d->noBorder )	


### PR DESCRIPTION
## Problem

YaST clients show a HUB signal error when the control center is closed before than the client. 

* https://bugzilla.suse.com/show_bug.cgi?id=1154854

## Solution

Launch clients with *nohup* command in order to not send a HUB signal when the control center is closed.

See also https://github.com/yast/yast-ruby-bindings/pull/276.

## Testing

Manually tested.
