### PR TITLE
Fix yast2 binary path

### DIFF
--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 26 14:27:27 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Use correct path for yast2 binary (related to bsc#1154854).
+- 4.4.2
+
+-------------------------------------------------------------------
 Wed Jul 21 14:43:12 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Run clients with nohup to avoid signal error messages when the

--- a/package/yast2-control-center.spec
+++ b/package/yast2-control-center.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-control-center
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Url:            https://github.com/yast/yast-control-center
 Summary:        YaST2 - Control Center

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -291,7 +291,7 @@ void MainWindow::slotLaunchModule( const QModelIndex &index)
     QString name = d->modmodel->data( i3, Qt::UserRole ).toString();
 
     // Do not send HUP signal when control center is closed, bsc#1154854.
-    QString cmd = QString("/usr/bin/nohup /sbin/yast2 ");
+    QString cmd = QString("/usr/bin/nohup /usr/sbin/yast2 ");
     cmd += client;
 
     if ( d->noBorder )	


### PR DESCRIPTION
## Problems

The deprecated */sbin/yast2* path is used to launch the YaST clients.

## Solution

Use the new */usr/bin/yast2* path.