### PR TITLE
Redirect nohup output

### DIFF
--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 13 15:49:40 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Avoid creating nohup.out file in the user's home directory
+  (bsc#1189651).
+- 4.4.3
+
+-------------------------------------------------------------------
 Mon Jul 26 14:27:27 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Use correct path for yast2 binary (related to bsc#1154854).

--- a/package/yast2-control-center.spec
+++ b/package/yast2-control-center.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-control-center
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Url:            https://github.com/yast/yast-control-center
 Summary:        YaST2 - Control Center

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -305,7 +305,9 @@ void MainWindow::slotLaunchModule( const QModelIndex &index)
 	cmd += argument;
 	cmd +="'";
     }
-    cmd += " &";
+
+    // Redirect nohup output to ensure that $HOME/nohup.out file is not created (bsc#1189651)
+    cmd += " > /var/log/YaST2/nohup.out 2>&1 &";
 
     //FIXME: use something more intelligent (unique) to remember used modules, names suck
     d->recentlyUsed.enqueue( name );  


### PR DESCRIPTION
### Problem

In the YaST Control Center, the YaST clients are launched with *nohup* command, see https://github.com/yast/yast-control-center/pull/51. But *nohup* is writing *nohup.out* file in the user's home directory. This will prevent to do a backup of the user's home if the backup is run by a non-root process.

* https://bugzilla.suse.com/show_bug.cgi?id=1189651


### Solution

The *nohup* output is redirected to the YaST log directory.


### Testing

Manually tested.
