### PR TITLE
Require xdg-utils

### DIFF
--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 31 15:33:15 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Require xdg-utils since it's no longer required by desktop-data-openSUSE
+  and yast-control-center-qt needs it to start modules with 'xdg-su'.
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-control-center.spec
+++ b/package/yast2-control-center.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-control-center
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Url:            https://github.com/yast/yast-control-center
 Summary:        YaST2 - Control Center
@@ -60,6 +60,8 @@ Requires:       yast2-control-center
 Requires:       libyui-qt
 # bsc#1130700: Need Qt SVG support for icons
 Requires:       libQt5Svg5
+# bsc#1211869: xdg-utils no longer automatically installed
+Requires:       xdg-utils
 
 Provides:       yast2-control-center-binary
 Provides:       yast2-control-center:%{_prefix}/lib/YaST2/bin/y2controlcenter


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1211869

## Trello

https://trello.com/c/6JNx9D7H/


## Problem

From Leap 15.3 to Leap 15.4, the _xdg-utils_ package that contains `xdg-su` which we need in our .desktop files to start YaST modules is no longer required by package _desktop-data-openSUSE anyway.

So it may happen that some installations end up without xdg-su, so YaST modules cannot be started from a desktop’s menu or from the YaST Qt control center.


## Overkill Solution (Not Done in this PR)

Add a requires: xdg-utils to every YaST package that comes with a .desktop file containing an `xdg-su` command line.

That would mean a ton of PRs for a very exotic situation.

## Pragmatic Solution (This PR)

Add `requires: xdg-utils` only to package _yast2-control-center-qt_.

This might not fix every pathological situation like using a simple window manager, not a full-fledged desktop, and deliberately not installing yast2-control-center-qt. But so be it.

## Will this Drag in a Ton of Dependencies? Like X11?

No. The _xdg-utils_ package has only minimalistic dependencies like Perl and some few Perl modules. And `xdg-su` is just a shell script that checks environment variables what desktop is in use and starts one of `kdesu`, `gnomesu` etc. or even an `xterm` with a `su -c` command line.