### PR TITLE
Use %make_build instead of %jobs (boo#1237231)

### DIFF
--- a/package/yast2-control-center.changes
+++ b/package/yast2-control-center.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 16 11:21:14 UTC 2025 - Bernhard Wiedemann <bwiedemann@suse.com>
+
+- Use %make_build instead of %jobs (boo#1237231)
+- 5.0.3
+
+-------------------------------------------------------------------
 Wed Jul 16 12:08:03 UTC 2025 - Dominique Leuenberger <dimstar@opensuse.org>
 
 - Allow building using CMake 4.0 by bumping the minimum for cmake

--- a/package/yast2-control-center.spec
+++ b/package/yast2-control-center.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-control-center
-Version:        5.0.2
+Version:        5.0.3
 Release:        0
 Url:            https://github.com/yast/yast-control-center
 Summary:        YaST2 - Control Center
@@ -90,7 +90,7 @@ cmake -DCMAKE_INSTALL_PREFIX=%{_prefix} \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_SKIP_RPATH=1 \
       ..
-make %{?jobs:-j %jobs} VERBOSE=1
+%make_build
 
 %install
 cd build


### PR DESCRIPTION
## Problem

- https://bugzilla.opensuse.org/show_bug.cgi?id=1237231

## Solution

Stop using (SUSE-specific) `%jobs`

## Testing

- *Tested manually*